### PR TITLE
Fix translations in ModernTimeline

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@mantine/core/styles.css";
-import "./module.css"
+import "./module.css";
 import {
   MantineProvider,
   createTheme,
@@ -10,10 +10,9 @@ import {
   AppShell,
 } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
-import { useDisclosure } from "@mantine/hooks";
-import { usePathname } from "next/navigation";
-import Providers, { useTheme } from "./providers";
+import Providers from "./providers";
 import Navbar from "../components/Navbar/Navbar"; // Your custom Navbar component
+import I18nClientProvider from "../components/I18nClientProvider";
 
 // Mantine theme configuration
 export const mantineThemeConfig = createTheme({
@@ -61,7 +60,7 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <AppShell>
       <AppShell.Header>
-        <Navbar/>
+        <Navbar />
       </AppShell.Header>
 
       <AppShell.Main style={{ paddingTop: 60 }}>{children}</AppShell.Main>
@@ -69,7 +68,11 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
       <head>
@@ -77,12 +80,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" href="/avatar.png" />
       </head>
       <body>
-        <MantineProvider theme={mantineThemeConfig}>
-          <Providers>
-            <Notifications />
-            <AppLayout>{children}</AppLayout>
-          </Providers>
-        </MantineProvider>
+        <I18nClientProvider>
+          <MantineProvider theme={mantineThemeConfig}>
+            <Providers>
+              <Notifications />
+              <AppLayout>{children}</AppLayout>
+            </Providers>
+          </MantineProvider>
+        </I18nClientProvider>
       </body>
     </html>
   );

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -7,6 +7,13 @@
     "takeRoad": "Discover the path I walk",
     "viewProjects": "Projects"
   },
+  "categories": {
+    "education": "Education",
+    "internships": "Internships",
+    "work": "Work Experience",
+    "volunteer": "Volunteer Work",
+    "more": "And many more to come"
+  },
   "career": {
     "school1": {
       "label": "Fontys University of Applied Sciences, Venlo",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -7,6 +7,13 @@
     "takeRoad": "Ontdek het pad dat ik bewandel",
     "viewProjects": "Projecten"
   },
+  "categories": {
+    "education": "Opleiding",
+    "internships": "Stages",
+    "work": "Werkervaring",
+    "volunteer": "Vrijwilligerswerk",
+    "more": "En nog veel meer om te komen"
+  },
   "career": {
     "school1": {
       "label": "Fontys Hogeschool Venlo",


### PR DESCRIPTION
## Summary
- wrap app with i18next provider so translations work
- add missing category translations in English and Dutch

## Testing
- `npm run test` *(fails: Prettier issues in unrelated files)*