### PR TITLE
Add language switcher to navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@mantine/core/styles.css";
-import "./module.css"
+import "./module.css";
 import {
   MantineProvider,
   createTheme,
@@ -10,9 +10,7 @@ import {
   AppShell,
 } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
-import { useDisclosure } from "@mantine/hooks";
-import { usePathname } from "next/navigation";
-import Providers, { useTheme } from "./providers";
+import Providers from "./providers";
 import Navbar from "../components/Navbar/Navbar"; // Your custom Navbar component
 
 // Mantine theme configuration
@@ -61,7 +59,7 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <AppShell>
       <AppShell.Header>
-        <Navbar/>
+        <Navbar />
       </AppShell.Header>
 
       <AppShell.Main style={{ paddingTop: 60 }}>{children}</AppShell.Main>
@@ -69,7 +67,11 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
       <head>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import Introduction from "@/components/Introduction/Introduction";
-import About from "@/components/About/About";
 import ModernTimeline from "@/components/CV/ModernTimeline/ModernTimeline";
 import SoftwareExperience from "@/components/SoftwareExperience/SoftwareExperience";
 import Contact from "@/components/Homepage/Contact";

--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -9,3 +9,21 @@
 .link:hover {
   color: var(--primary);
 }
+
+.langSwitcher {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.langBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.4rem;
+  filter: grayscale(0.6);
+  transition: filter 0.2s ease;
+}
+
+.langActive {
+  filter: none;
+}

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -10,14 +10,9 @@ import {
   Burger,
   Stack,
 } from "@mantine/core";
+import { useTranslation } from "react-i18next";
 import { useDisclosure } from "@mantine/hooks";
-import {
-  IconBrandTiktok,
-  IconBrandYoutube,
-  IconBrandFacebook,
-  IconBrandInstagram,
-  IconBrandLinkedin,
-} from "@tabler/icons-react";
+import { IconBrandLinkedin } from "@tabler/icons-react";
 import classes from "./Navbar.module.css";
 
 const LINKS = [
@@ -25,12 +20,17 @@ const LINKS = [
   { label: "CONTACT", href: "/contact" },
 ];
 
-const SOCIALS = [
-  { href: "https://www.linkedin.com", Icon: IconBrandLinkedin },
+const SOCIALS = [{ href: "https://www.linkedin.com", Icon: IconBrandLinkedin }];
+
+const LANGS = [
+  { code: "nl", label: "Nederlands", flag: "🇳🇱" },
+  { code: "en", label: "English", flag: "🇬🇧" },
 ];
 
 export default function Navbar() {
   const [opened, { toggle, close }] = useDisclosure(false);
+  const { i18n } = useTranslation();
+  const currentLang = i18n.language || "nl";
 
   const navLinks = LINKS.map((link) => (
     <a key={link.href} href={link.href} className={classes.link}>
@@ -74,6 +74,21 @@ export default function Navbar() {
           <Group gap="xs" visibleFrom="sm" c="gray.0">
             {icons}
           </Group>
+          <nav className={classes.langSwitcher} aria-label="Language switcher">
+            {LANGS.map((lang) => (
+              <button
+                key={lang.code}
+                onClick={() => i18n.changeLanguage(lang.code)}
+                className={`${classes.langBtn} ${
+                  currentLang === lang.code ? classes.langActive : ""
+                }`}
+                aria-label={lang.label}
+                type="button"
+              >
+                {lang.flag}
+              </button>
+            ))}
+          </nav>
           <Button
             component="a"
             href="/list-your-property"
@@ -118,6 +133,24 @@ export default function Navbar() {
           ))}
           <Group gap="xs" mt="md">
             {icons}
+          </Group>
+          <Group gap="xs">
+            {LANGS.map((lang) => (
+              <button
+                key={lang.code}
+                onClick={() => {
+                  i18n.changeLanguage(lang.code);
+                  close();
+                }}
+                className={`${classes.langBtn} ${
+                  currentLang === lang.code ? classes.langActive : ""
+                }`}
+                aria-label={lang.label}
+                type="button"
+              >
+                {lang.flag}
+              </button>
+            ))}
           </Group>
         </Stack>
       </Drawer>


### PR DESCRIPTION
## Summary
- add react-i18next to Navbar and allow switching language
- expose language buttons in main navbar and drawer
- provide minimal CSS for language switcher
- clean unused imports in layout and homepage

## Testing
- `npm test` *(fails: ESLint and typecheck errors in unrelated files)*