### PR TITLE
Add theme dropdown to navbar

### DIFF
--- a/app/module.css
+++ b/app/module.css
@@ -3,4 +3,16 @@
   --bg-dark: #0d0d0d;
   --card-bg: #181818f2;
   --card-radius: 18px;
+  --navbar-bg: #ffffff;
+  --navbar-color: #000000;
+}
+
+.theme-dark {
+  --navbar-bg: #333333;
+  --navbar-color: #ffffff;
+}
+
+.theme-light {
+  --navbar-bg: #ffffff;
+  --navbar-color: #000000;
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -13,6 +13,7 @@ import { notifications } from "@mantine/notifications";
 interface ThemeContextType {
   theme: "theme-dark" | "theme-light";
   toggleTheme: () => void;
+  setThemeMode: (mode: "theme-dark" | "theme-light") => void;
 }
 
 // Create the context with a default undefined value
@@ -71,8 +72,12 @@ export default function Providers({ children }: { children: ReactNode }) {
     setTheme((prev) => (prev === "theme-dark" ? "theme-light" : "theme-dark"));
   };
 
+  const setThemeMode = (mode: "theme-dark" | "theme-light") => {
+    setTheme(mode);
+  };
+
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, setThemeMode }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -22,3 +22,15 @@
 .brandText {
   font-weight: 700;
 }
+
+.themeButton {
+  background: var(--navbar-bg);
+  color: var(--navbar-color);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dropdown {
+  background: var(--navbar-bg);
+  color: var(--navbar-color);
+}

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   Group,
   Burger,
   Stack,
+  Menu,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {
@@ -17,20 +18,21 @@ import {
   IconBrandFacebook,
   IconBrandInstagram,
   IconBrandLinkedin,
+  IconChevronDown,
 } from "@tabler/icons-react";
 import classes from "./Navbar.module.css";
+import { useTheme } from "../../app/providers";
 
 const LINKS = [
   { label: "PROJECTS", href: "/projects" },
   { label: "CONTACT", href: "/contact" },
 ];
 
-const SOCIALS = [
-  { href: "https://www.linkedin.com", Icon: IconBrandLinkedin },
-];
+const SOCIALS = [{ href: "https://www.linkedin.com", Icon: IconBrandLinkedin }];
 
 export default function Navbar() {
   const [opened, { toggle, close }] = useDisclosure(false);
+  const { theme, setThemeMode } = useTheme();
 
   const navLinks = LINKS.map((link) => (
     <a key={link.href} href={link.href} className={classes.link}>
@@ -51,6 +53,8 @@ export default function Navbar() {
       <Icon size={20} />
     </ActionIcon>
   ));
+
+  const themeLabel = theme === "theme-light" ? "Light" : "Dark";
 
   return (
     <Box component="header" w="100%">
@@ -75,6 +79,24 @@ export default function Navbar() {
           <Group gap="xs" visibleFrom="sm" c="gray.0">
             {icons}
           </Group>
+          <Menu>
+            <Menu.Target>
+              <Button
+                className={classes.themeButton}
+                rightSection={<IconChevronDown size={14} />}
+              >
+                {themeLabel}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown className={classes.dropdown}>
+              <Menu.Item onClick={() => setThemeMode("theme-light")}>
+                Light
+              </Menu.Item>
+              <Menu.Item onClick={() => setThemeMode("theme-dark")}>
+                Dark
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
           <Button
             component="a"
             href="/list-your-property"
@@ -119,6 +141,34 @@ export default function Navbar() {
           ))}
           <Group gap="xs" mt="md">
             {icons}
+            <Menu>
+              <Menu.Target>
+                <Button
+                  className={classes.themeButton}
+                  rightSection={<IconChevronDown size={14} />}
+                >
+                  {themeLabel}
+                </Button>
+              </Menu.Target>
+              <Menu.Dropdown className={classes.dropdown}>
+                <Menu.Item
+                  onClick={() => {
+                    setThemeMode("theme-light");
+                    close();
+                  }}
+                >
+                  Light
+                </Menu.Item>
+                <Menu.Item
+                  onClick={() => {
+                    setThemeMode("theme-dark");
+                    close();
+                  }}
+                >
+                  Dark
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
           </Group>
         </Stack>
       </Drawer>


### PR DESCRIPTION
## Summary
- allow setting light or dark theme in `Providers`
- expose theme dropdown in navbar for desktop and drawer mobile navigation
- add styling hooks for theme toggle

## Testing
- `npm test` *(fails: Code style issues found)*