### PR TITLE
Fix projects timeline mobile layout

### DIFF
--- a/app/projects/projects.module.css
+++ b/app/projects/projects.module.css
@@ -133,7 +133,7 @@
       gap: 1rem;
     }
     .entry::before {
-      left: 0;
+      left: 8px;
       transform: translate(-50%, -50%);
     }
     .card {


### PR DESCRIPTION
## Summary
- fix left offset for project timeline bullet on mobile so it aligns with the vertical line

## Testing
- `npm run test`
