### PR TITLE
Move LinkedIn icon below menu items

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   Burger,
   Stack,
   Menu,
+  Divider,
 } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import { useDisclosure } from "@mantine/hooks";
@@ -53,7 +54,8 @@ export default function Navbar() {
       target="_blank"
       rel="noopener noreferrer"
       variant="subtle"
-      color="gray.0"
+      color={theme === "theme-light" ? "#202124" : "#ffffff"}
+      aria-label="LinkedIn"
     >
       <Icon size={20} />
     </ActionIcon>
@@ -150,7 +152,6 @@ export default function Navbar() {
             </a>
           ))}
           <Group gap="xs" mt="md">
-            {icons}
             <Menu>
               <Menu.Target>
                 <Button
@@ -197,6 +198,10 @@ export default function Navbar() {
                 {lang.flag}
               </button>
             ))}
+          </Group>
+          <Divider my="sm" />
+          <Group gap="xs" justify="center">
+            {icons}
           </Group>
         </Stack>
       </Drawer>


### PR DESCRIPTION
## Summary
- show LinkedIn icon at bottom of mobile drawer
- keep icon color in sync with theme

## Testing
- `npm test`