### PR TITLE
Add translations across site

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Notifications } from "@mantine/notifications";
 import Providers from "./providers";
 import Navbar from "../components/Navbar/Navbar"; // Your custom Navbar component
 import I18nClientProvider from "../components/I18nClientProvider";
+import { useTranslation } from "react-i18next";
 
 function AppLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -25,8 +26,9 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const { i18n } = useTranslation();
   return (
-    <html lang="en">
+    <html lang={i18n.language}>
       <head>
         <title>Curriculum Vitae</title>
         <link rel="icon" href="/avatar.png" />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,6 +6,7 @@ import {
   IconBrandGithub,
   IconBrandLinkedin,
 } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
 import classes from "./projects.module.css";
 
 export interface Project {
@@ -73,6 +74,7 @@ const projects: Project[] = [
 const sorted = [...projects].sort((a, b) => b.year - a.year);
 
 export default function ProjectsPage() {
+  const { t } = useTranslation();
   return (
     <section id="projects" className={classes.wrapper}>
       <div className={classes.container}>
@@ -84,11 +86,11 @@ export default function ProjectsPage() {
           }}
         >
           <Button component="a" href="/" variant="light" radius="xl">
-            Back to main page
+            {t("projects.back")}
           </Button>
         </div>
 
-        <h1 className={classes.headingPrimary}>My Projects</h1>
+        <h1 className={classes.headingPrimary}>{t("projects.heading")}</h1>
 
         {sorted.map((project, idx) => {
           const side = idx % 2 === 0 ? classes.right : classes.left;

--- a/components/About/About.tsx
+++ b/components/About/About.tsx
@@ -1,9 +1,21 @@
 // components/AboutMe/AboutMe.tsx
 "use client";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import classes from "./About.module.css";
 
 export default function AboutMe() {
+  const { t } = useTranslation();
+
+  const paragraph = t("about.paragraph")
+    .split("\n")
+    .map((line, idx) => (
+      <React.Fragment key={idx}>
+        {line}
+        <br />
+      </React.Fragment>
+    ));
+
   return (
     <section id="about" className={classes.wrapper}>
       <div className={classes.inner}>
@@ -14,30 +26,8 @@ export default function AboutMe() {
 
         {/* Right – introduction */}
         <article className={classes.content}>
-          <h2 className={classes.heading}>Who I Am</h2>
-          <p className={classes.paragraph}>
-            I’m Koen van Wijlick — a mechatronics engineer turned AI enthusiast
-            on a mission to make technlogies smarter and more sustainable. From
-            a young age I was fascinated by how mechanical systems spring to
-            life when guided by clever software, and that curiosity led me
-            through a degree in Mechatronics and deep dives into robotics,
-            computer vision and autonomous control. Today I build greenhouse
-            robots that see, think and act on their own, freeing growers to
-            focus on cultivating healthier crops while saving precious
-            resources.
-            <br />
-            <br />I thrive where hardware meets code: designing precision
-            mechanics in SolidWorks, wiring up ROS 2 nodes in C++ and squeezing
-            every last bit of insight from camera feeds with Python and YOLO.
-            Collaboration, transparent communication and relentless iteration
-            are my trademarks; I believe great tech emerges when diverse minds
-            unite around a shared goal. Beyond the lab you’ll find me running
-            woodland trails, sketching new interface ideas or sharing knowledge
-            at local maker meet‑ups. I strive to craft solutions that are not
-            only technically elegant but also genuinely helpful for people and
-            planet. If that resonates with you, let’s connect and grow something
-            extraordinary together.
-          </p>
+          <h2 className={classes.heading}>{t("about.heading")}</h2>
+          <p className={classes.paragraph}>{paragraph}</p>
         </article>
       </div>
     </section>

--- a/components/Homepage/Contact.tsx
+++ b/components/Homepage/Contact.tsx
@@ -1,6 +1,7 @@
 // components/Contact/Contact.tsx
 "use client";
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Stack,
   Group,
@@ -14,6 +15,7 @@ import { DateInput } from "@mantine/dates";
 import classes from "./Contact.module.css";
 
 export default function Contact() {
+  const { t } = useTranslation();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [reason, setReason] = useState("");
@@ -30,17 +32,17 @@ export default function Contact() {
   return (
     <section className={classes.wrapper} id="contact">
       <Paper component="form" onSubmit={handleSubmit} className={classes.form}>
-        <h2 className={classes.heading}>Let’s Talk</h2>
+        <h2 className={classes.heading}>{t("contact.heading")}</h2>
         <Stack gap="sm">
           <TextInput
-            label="Name"
+            label={t("contact.name")}
             value={name}
             onChange={(e) => setName(e.currentTarget.value)}
             required
             classNames={{ root: classes.inputRoot }}
           />
           <TextInput
-            label="Email"
+            label={t("contact.email")}
             type="email"
             value={email}
             onChange={(e) => setEmail(e.currentTarget.value)}
@@ -48,7 +50,7 @@ export default function Contact() {
             classNames={{ root: classes.inputRoot }}
           />
           <Textarea
-            label="Reason for contact"
+            label={t("contact.reason")}
             value={reason}
             onChange={(e) => setReason(e.currentTarget.value)}
             autosize
@@ -56,7 +58,7 @@ export default function Contact() {
             classNames={{ root: classes.inputRoot }}
           />
           <DateInput
-            label="Preferred date"
+            label={t("contact.preferredDate")}
             value={date}
             onChange={(v) => setDate(v as Date | null)}
             clearable
@@ -64,14 +66,14 @@ export default function Contact() {
           />
           <Group justify="flex-end">
             <Button type="submit" radius="xl" className={classes.submitBtn}>
-              Submit
+              {t("contact.submit")}
             </Button>
           </Group>
           {submitted && (
             <p
               style={{ textAlign: "center", color: "var(--accent)", margin: 0 }}
             >
-              Thanks! I’ll be in touch soon.
+              {t("contact.thanks")}
             </p>
           )}
         </Stack>

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -19,10 +19,10 @@ import classes from "./Navbar.module.css";
 import { useTheme } from "../../app/providers";
 
 const LINKS = [
-  { label: "HOME", href: "/" },
-  { label: "PROJECTS", href: "/projects" },
+  { key: "navbar.home", href: "/" },
+  { key: "navbar.projects", href: "/projects" },
   // Link to the contact section on the homepage
-  { label: "CONTACT", href: "/#contact" },
+  { key: "navbar.contact", href: "/#contact" },
 ];
 
 const SOCIALS = [
@@ -40,11 +40,11 @@ const LANGS = [
 export default function Navbar() {
   const [opened, { toggle, close }] = useDisclosure(false);
   const { theme, setThemeMode } = useTheme();
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
   const currentLang = i18n.language || "nl";
   const navLinks = LINKS.map((link) => (
     <a key={link.href} href={link.href} className={classes.link}>
-      {link.label}
+      {t(link.key)}
     </a>
   ));
 
@@ -63,7 +63,8 @@ export default function Navbar() {
     </ActionIcon>
   ));
 
-  const themeLabel = theme === "theme-light" ? "Light" : "Dark";
+  const themeLabel =
+    theme === "theme-light" ? t("navbar.light") : t("navbar.dark");
 
   return (
     <Box component="header" w="100%" className={classes.navbar}>
@@ -72,10 +73,10 @@ export default function Navbar() {
           <a href="/" className={classes.brand}>
             <img src="/Icon.png" alt="Logo" height={32} />
             <Box visibleFrom="sm" className={classes.brandText}>
-              Ciriculum vitea
+              {t("navbar.brandFull")}
             </Box>
             <Box hiddenFrom="sm" className={classes.brandText}>
-              CV
+              {t("navbar.brandShort")}
             </Box>
           </a>
           <Group gap="md" visibleFrom="sm">
@@ -118,10 +119,10 @@ export default function Navbar() {
               </Menu.Target>
               <Menu.Dropdown className={classes.dropdown}>
                 <Menu.Item onClick={() => setThemeMode("theme-light")}>
-                  Light
+                  {t("navbar.light")}
                 </Menu.Item>
                 <Menu.Item onClick={() => setThemeMode("theme-dark")}>
-                  Dark
+                  {t("navbar.dark")}
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>
@@ -151,7 +152,7 @@ export default function Navbar() {
               onClick={close}
               className={classes.link}
             >
-              {link.label}
+              {t(link.key)}
             </a>
           ))}
           <Group gap="xs" mt="md">
@@ -171,7 +172,7 @@ export default function Navbar() {
                     close();
                   }}
                 >
-                  Light
+                  {t("navbar.light")}
                 </Menu.Item>
                 <Menu.Item
                   onClick={() => {
@@ -179,7 +180,7 @@ export default function Navbar() {
                     close();
                   }}
                 >
-                  Dark
+                  {t("navbar.dark")}
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>

--- a/components/Skills/Skills.tsx
+++ b/components/Skills/Skills.tsx
@@ -1,6 +1,7 @@
 // components/Skills/Skills.tsx
 "use client";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import classes from "./Skills.module.css";
 
 type Skill = {
@@ -10,38 +11,39 @@ type Skill = {
 
 const skills: Skill[] = [
   {
-    category: "Frontend",
+    category: "skills.frontend",
     tools: ["React", "Next.js", "TypeScript", "MUI", "Tailwind"],
   },
   {
-    category: "Backend & APIs",
+    category: "skills.backend",
     tools: ["FastAPI", "Node.js", "MQTT", "Redis", "WebSockets"],
   },
   {
-    category: "Data & AI",
+    category: "skills.data",
     tools: ["Python", "TensorFlow", "YOLO", "OpenCV", "ROS 2"],
   },
   {
-    category: "DevOps",
+    category: "skills.devops",
     tools: ["Docker", "Git", "GitHub Actions", "Linux"],
   },
   {
-    category: "Databases",
+    category: "skills.databases",
     tools: ["PostgreSQL", "SQLite", "Supabase"],
   },
   {
-    category: "CAD / CAM",
+    category: "skills.cad",
     tools: ["SolidWorks", "Inventor", "AutoCAD"],
   },
 ];
 
 export default function Skills() {
+  const { t } = useTranslation();
   return (
     <section id="skills" className={classes.wrapper}>
       <div className={classes.inner}>
         {skills.map((skill) => (
           <article key={skill.category} className={classes.skillCard}>
-            <h3 className={classes.skillTitle}>{skill.category}</h3>
+            <h3 className={classes.skillTitle}>{t(skill.category)}</h3>
             <div className={classes.tagGrid}>
               {skill.tools.map((tool) => (
                 <span key={tool} className={classes.tag}>

--- a/components/SoftwareExperience/SoftwareExperience.tsx
+++ b/components/SoftwareExperience/SoftwareExperience.tsx
@@ -2,74 +2,40 @@
 "use client";
 import { Stack } from "@mantine/core";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import classes from "./SoftwareExperience.module.css";
 
 export default function SoftwareExperience() {
+  const { t } = useTranslation();
   return (
     <section id="certs" className={classes.wrapper}>
       <div className={classes.inner}>
         <Stack gap="xs">
-          <h2 className={classes.headingPrimary}>
-            Software Experience & Certifications
-          </h2>
+          <h2 className={classes.headingPrimary}>{t("software.heading")}</h2>
 
           {/* Certifications */}
-          <h3 className={classes.headingSecondary}>Certifications</h3>
+          <h3 className={classes.headingSecondary}>
+            {t("software.certHeading")}
+          </h3>
           <ul className={classes.list}>
-            <li className={classes.listItem}>
-              <strong>SolidWorks Mechanical Design Associate</strong> – Issued:
-              May 2019 – No expiration. Credential ID: C‑5SUCTJW3L4. Validated
-              proficiency in 3 D CAD modelling, assembly creation and drawings
-              using SolidWorks.
-            </li>
-            <li className={classes.listItem}>
-              <strong>Basisveiligheid VCA</strong> – Issued: March 2018 –
-              Expires: March 2028. Credential ID: 541448.05174689. Certified in
-              occupational health & safety for high‑risk environments
-              (Dutch/Belgian VCA standards).
-            </li>
+            <li className={classes.listItem}>{t("software.cert1")}</li>
+            <li className={classes.listItem}>{t("software.cert2")}</li>
           </ul>
 
           {/* Software & Skills */}
           <h3 className={classes.headingSecondary}>
-            Software & Programming Skills
+            {t("software.skillsHeading")}
           </h3>
           <ul className={classes.list}>
-            <li className={classes.listItem}>
-              <strong>Python, C++</strong> – Robotics, AI, computer vision
-              (YOLO, ROS 2, OpenCV)
-            </li>
-            <li className={classes.listItem}>
-              <strong>React, TypeScript, JavaScript</strong> – Modern frontend
-              development
-            </li>
-            <li className={classes.listItem}>
-              <strong>PostgreSQL, SQLite</strong> – Database design &
-              integration
-            </li>
-            <li className={classes.listItem}>
-              <strong>FastAPI, MQTT</strong> – Backend APIs & real‑time comms
-            </li>
-            <li className={classes.listItem}>
-              <strong>Docker, Git, Linux</strong> – Containerisation, version
-              control & ops
-            </li>
-            <li className={classes.listItem}>
-              <strong>Siemens PLC (TIA Portal)</strong> – Industrial automation
-              & control
-            </li>
-            <li className={classes.listItem}>
-              <strong>SolidWorks, Inventor, AutoCAD</strong> – 3 D modelling & 2
-              D schematics
-            </li>
-            <li className={classes.listItem}>
-              <strong>Redis, WebSockets</strong> – In‑memory data storage & live
-              streaming
-            </li>
-            <li className={classes.listItem}>
-              <strong>Next.js, MUI</strong> – Full‑stack web apps &
-              component‑driven UI
-            </li>
+            <li className={classes.listItem}>{t("software.skill1")}</li>
+            <li className={classes.listItem}>{t("software.skill2")}</li>
+            <li className={classes.listItem}>{t("software.skill3")}</li>
+            <li className={classes.listItem}>{t("software.skill4")}</li>
+            <li className={classes.listItem}>{t("software.skill5")}</li>
+            <li className={classes.listItem}>{t("software.skill6")}</li>
+            <li className={classes.listItem}>{t("software.skill7")}</li>
+            <li className={classes.listItem}>{t("software.skill8")}</li>
+            <li className={classes.listItem}>{t("software.skill9")}</li>
           </ul>
         </Stack>
       </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -71,5 +71,55 @@
       "sub": "May 2018 to March 2019",
       "info": "Internship (MBO level 4, year 3)\nGained broad experience in mechatronics through multiple internships. Tasks: drawing 2D electrical schematics, Excel calculations for mechanical components, assembling control cabinets, and cross-department collaboration for a solid foundation in industrial automation and design."
     }
+  },
+  "about": {
+    "heading": "Who I Am",
+    "paragraph": "I’m Koen van Wijlick — a mechatronics engineer turned AI enthusiast on a mission to make technologies smarter and more sustainable. From a young age I was fascinated by how mechanical systems spring to life when guided by clever software, and that curiosity led me through a degree in Mechatronics and deep dives into robotics, computer vision and autonomous control. Today I build greenhouse robots that see, think and act on their own, freeing growers to focus on cultivating healthier crops while saving precious resources.\n\nI thrive where hardware meets code: designing precision mechanics in SolidWorks, wiring up ROS 2 nodes in C++ and squeezing every last bit of insight from camera feeds with Python and YOLO. Collaboration, transparent communication and relentless iteration are my trademarks; I believe great tech emerges when diverse minds unite around a shared goal. Beyond the lab you’ll find me running woodland trails, sketching new interface ideas or sharing knowledge at local maker meet‑ups. I strive to craft solutions that are not only technically elegant but also genuinely helpful for people and planet. If that resonates with you, let’s connect and grow something extraordinary together."
+  },
+  "navbar": {
+    "home": "Home",
+    "projects": "Projects",
+    "contact": "Contact",
+    "brandFull": "Curriculum Vitae",
+    "brandShort": "CV",
+    "light": "Light",
+    "dark": "Dark"
+  },
+  "contact": {
+    "heading": "Let’s Talk",
+    "name": "Name",
+    "email": "Email",
+    "reason": "Reason for contact",
+    "preferredDate": "Preferred date",
+    "submit": "Submit",
+    "thanks": "Thanks! I’ll be in touch soon."
+  },
+  "software": {
+    "heading": "Software Experience & Certifications",
+    "certHeading": "Certifications",
+    "skillsHeading": "Software & Programming Skills",
+    "cert1": "SolidWorks Mechanical Design Associate – Issued: May 2019 – No expiration. Credential ID: C-5SUCTJW3L4. Validated proficiency in 3D CAD modeling, assembly creation and drawings using SolidWorks.",
+    "cert2": "Basisveiligheid VCA – Issued: March 2018 – Expires: March 2028. Credential ID: 541448.05174689. Certified in occupational health & safety for high‑risk environments (Dutch/Belgian VCA standards).",
+    "skill1": "Python, C++ – Robotics, AI, computer vision (YOLO, ROS 2, OpenCV)",
+    "skill2": "React, TypeScript, JavaScript – Modern frontend development",
+    "skill3": "PostgreSQL, SQLite – Database design & integration",
+    "skill4": "FastAPI, MQTT – Backend APIs & real‑time comms",
+    "skill5": "Docker, Git, Linux – Containerisation, version control & ops",
+    "skill6": "Siemens PLC (TIA Portal) – Industrial automation & control",
+    "skill7": "SolidWorks, Inventor, AutoCAD – 3D modelling & 2D schematics",
+    "skill8": "Redis, WebSockets – In‑memory data storage & live streaming",
+    "skill9": "Next.js, MUI – Full‑stack web apps & component‑driven UI"
+  },
+  "skills": {
+    "frontend": "Frontend",
+    "backend": "Backend & APIs",
+    "data": "Data & AI",
+    "devops": "DevOps",
+    "databases": "Databases",
+    "cad": "CAD / CAM"
+  },
+  "projects": {
+    "heading": "My Projects",
+    "back": "Back to main page"
   }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -70,5 +70,55 @@
       "sub": "mei 2018 – maart 2019",
       "info": "Stage (MBO niveau 4, jaar 3)\nVerkreeg brede ervaring in mechatronica via meerdere stages. Taken: 2D-elektrische schema’s tekenen, Excel-berekeningen voor mechanische componenten, schakelkasten assembleren en afdelingsoverschrijdende samenwerking voor een sterke basis in industriële automatisering en ontwerp."
     }
+  },
+  "about": {
+    "heading": "Wie ik ben",
+    "paragraph": "Ik ben Koen van Wijlick — een mechatronica‑ingenieur die zich heeft ontwikkeld tot AI‑enthousiasteling met een missie om technologie slimmer en duurzamer te maken. Van jongs af aan was ik gefascineerd door hoe mechanische systemen tot leven komen met slimme software. Die nieuwsgierigheid leidde tot een studie Mechatronica en verdiepingen in robotica, computer vision en autonome besturing. Tegenwoordig bouw ik kasrobots die zelf zien, denken en handelen, zodat telers zich kunnen richten op gezondere gewassen en waardevolle middelen besparen.\n\nIk floreer waar hardware en code samenkomen: precisie­mechanica ontwerpen in SolidWorks, ROS 2‑nodes programmeren in C++ en elk detail uit camerabeelden halen met Python en YOLO. Samenwerking, open communicatie en voortdurend verbeteren kenmerken mijn aanpak; sterke technologie ontstaat wanneer verschillende mensen zich scharen achter een gemeenschappelijk doel. Buiten het lab ren ik graag door het bos, schets ik nieuwe interface‑ideeën of deel ik kennis op lokale makersbijeenkomsten. Ik streef naar oplossingen die niet alleen technisch doordacht zijn maar ook echt iets bijdragen aan mens en milieu. Spreekt dat je aan? Laten we samen iets bijzonders opbouwen."
+  },
+  "navbar": {
+    "home": "Home",
+    "projects": "Projecten",
+    "contact": "Contact",
+    "brandFull": "Curriculum Vitae",
+    "brandShort": "CV",
+    "light": "Licht",
+    "dark": "Donker"
+  },
+  "contact": {
+    "heading": "Laten we praten",
+    "name": "Naam",
+    "email": "E‑mail",
+    "reason": "Reden van contact",
+    "preferredDate": "Voorkeursdatum",
+    "submit": "Versturen",
+    "thanks": "Bedankt! Ik neem snel contact op."
+  },
+  "software": {
+    "heading": "Softwareervaring & certificaten",
+    "certHeading": "Certificaten",
+    "skillsHeading": "Software- en programmeervaardigheden",
+    "cert1": "SolidWorks Mechanical Design Associate – Uitgegeven: mei 2019 – geen vervaldatum. Credential ID: C-5SUCTJW3L4. Bevestigt vaardigheid in 3D CAD-modelleren, assemblages maken en tekeningen opstellen met SolidWorks.",
+    "cert2": "Basisveiligheid VCA – Uitgegeven: maart 2018 – Verloopt: maart 2028. Credential ID: 541448.05174689. Gecertificeerd voor veiligheid en gezondheid in risicovolle omgevingen volgens de Nederlandse/Belgische VCA-norm.",
+    "skill1": "Python, C++ – Robotica, AI, computer vision (YOLO, ROS 2, OpenCV)",
+    "skill2": "React, TypeScript, JavaScript – Moderne frontendontwikkeling",
+    "skill3": "PostgreSQL, SQLite – Databaseontwerp & integratie",
+    "skill4": "FastAPI, MQTT – Backend-API’s & realtime-communicatie",
+    "skill5": "Docker, Git, Linux – Containerisatie, versiebeheer & operations",
+    "skill6": "Siemens PLC (TIA Portal) – Industriële automatisering & besturing",
+    "skill7": "SolidWorks, Inventor, AutoCAD – 3D-modelleren & 2D-schema’s",
+    "skill8": "Redis, WebSockets – In-memory opslag & live datastreaming",
+    "skill9": "Next.js, MUI – Fullstack webapps & componentgedreven UI"
+  },
+  "skills": {
+    "frontend": "Frontend",
+    "backend": "Backend & API’s",
+    "data": "Data & AI",
+    "devops": "DevOps",
+    "databases": "Databases",
+    "cad": "CAD / CAM"
+  },
+  "projects": {
+    "heading": "Mijn projecten",
+    "back": "Terug naar hoofdpagina"
   }
 }


### PR DESCRIPTION
## Summary
- provide complete i18n strings in English and Dutch
- hook up translations in About page
- hook up translations in Contact form
- update Navbar to use translations and dynamic brand text
- translate skills categories
- add translations for software experience
- translate projects page
- set html language dynamically

## Testing
- `npm run test`