### PR TITLE
Fix language persistence across pages

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,6 @@
 // components/ProjectsTimeline/ProjectsTimeline.tsx
 "use client";
-import { Badge, Button, Group, Paper, Text, ActionIcon } from "@mantine/core";
+import { Badge, Group, Paper, Text, ActionIcon } from "@mantine/core";
 import {
   IconWorld,
   IconBrandGithub,

--- a/components/I18nClientProvider.tsx
+++ b/components/I18nClientProvider.tsx
@@ -1,11 +1,30 @@
 "use client";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../src/i18n";
+import { useEffect } from "react";
 
 export default function I18nClientProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("cv-lang");
+      if (stored && stored !== i18n.language) {
+        i18n.changeLanguage(stored);
+      }
+
+      const handleChange = (lng: string) => {
+        localStorage.setItem("cv-lang", lng);
+      };
+
+      i18n.on("languageChanged", handleChange);
+      return () => {
+        i18n.off("languageChanged", handleChange);
+      };
+    }
+  }, []);
+
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/components/Introduction/Introduction.tsx
+++ b/components/Introduction/Introduction.tsx
@@ -1,6 +1,7 @@
 // components/Introduction/Introduction.tsx
 "use client";
 import React from "react";
+import Link from "next/link";
 import { Button, Group } from "@mantine/core";
 import {
   IconBrandGithub,
@@ -75,7 +76,7 @@ export default function Introduction() {
             variant="outline"
             radius="xl"
             size="md"
-            component="a"
+            component={Link}
             href="/projects"
             leftSection={<IconRocket size={18} />}
           >

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Link from "next/link";
 import {
   ActionIcon,
   Burger,
@@ -51,17 +52,17 @@ export default function Navbar() {
     <header className={classes.navbar}>
       <div className={classes.inner}>
         {/* Brand */}
-        <a href="/" className={classes.brand}>
+        <Link href="/" className={classes.brand}>
           <img src="/Icon.png" alt="Logo" className={classes.brandLogo} />
           <span className={classes.brandText}>Personal&nbsp;Profile&nbsp;</span>
-        </a>
+        </Link>
 
         {/* Links */}
         <nav className={classes.links} aria-label="Primary">
           {LINKS.map((link) => (
-            <a key={link.href} href={link.href} className={classes.link}>
+            <Link key={link.href} href={link.href} className={classes.link}>
               {link.label}
-            </a>
+            </Link>
           ))}
         </nav>
 
@@ -132,14 +133,14 @@ export default function Navbar() {
       <Drawer opened={opened} onClose={close} size="100%" padding="md">
         <Stack gap="lg">
           {LINKS.map((link) => (
-            <a
+            <Link
               key={link.href}
               href={link.href}
               onClick={close}
               className={classes.drawerLink}
             >
               {link.label}
-            </a>
+            </Link>
           ))}
           <Group gap="sm">
             {LANGS.map((lang) => (


### PR DESCRIPTION
## Summary
- persist selected language with `localStorage` in `I18nClientProvider`
- use Next.js `Link` for internal navigation
- remove unused import from projects page

## Testing
- `npm test`