### PR TITLE
Enhance skills section styling

### DIFF
--- a/components/Skills/Skills.module.css
+++ b/components/Skills/Skills.module.css
@@ -1,69 +1,73 @@
 .wrapper {
-    position: relative;
-    padding: clamp(4rem, 7vw, 6rem) 1rem;
-    display: flex;
-    background: transparent;
-    justify-content: center;
-    color: var(--light-text);
+  position: relative;
+  padding: clamp(4rem, 7vw, 6rem) 1rem;
+  display: flex;
+  background: transparent;
+  justify-content: center;
+  color: var(--light-text);
+}
 
-  }
-  
-  .inner {
-    position: relative;
-    z-index: 1;
-    max-width: 1080px;
-    width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1.25rem;
-  }
-  
+.inner {
+  position: relative;
+  z-index: 1;
+  max-width: 1080px;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
 .skillCard {
-    box-sizing: border-box;
-    background: var(--card-bg);
-    border-radius: var(--card-radius);
-    padding: 1.25rem 1.5rem;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.6rem;
-    box-shadow: 0 8px 28px rgb(0 0 0 / 0.35);
-    backdrop-filter: blur(6px);
-    transition: transform 0.25s ease;
+  box-sizing: border-box;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.08),
+    rgba(255, 255, 255, 0.02)
+  );
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.8rem;
+  box-shadow: 0 10px 32px rgb(0 0 0 / 0.35);
+  backdrop-filter: blur(8px);
+  transition: transform 0.25s ease;
+}
+
+.skillCard:hover {
+  transform: translateY(-6px) scale(1.02);
+}
+
+.skillTitle {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-size: clamp(1.6rem, 2.6vw, 2rem);
+  letter-spacing: 0.03em;
+  margin: 0;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.tagGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.1;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 576px) {
+  .inner {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   }
-  
-  .skillCard:hover {
-    transform: translateY(-6px) scale(1.02);
-  }
-  
-  .skillTitle {
-    font-family: "Bebas Neue", "Oswald", sans-serif;
-    font-size: clamp(1.4rem, 2.4vw, 1.8rem);
-    letter-spacing: 0.02em;
-    margin: 0;
-    color: var(--accent);
-    text-transform: uppercase;
-  }
-  
-  .tagGrid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-  }
-  
-  .tag {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 9999px;
-    padding: 0.25rem 0.65rem;
-    font-size: 0.75rem;
-    line-height: 1.1;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-  }
-  
-  @media (max-width: 576px) {
-    .inner {
-      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    }
-  }
+}


### PR DESCRIPTION
## Summary
- enlarge skills card grid and padding
- modernize card appearance with gradient background and borders
- adjust tag styles for better readability
- tweak mobile layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d40fe86d88326a445bf5d80d8dc7f