### PR TITLE
Fix mobile heading for certifications

### DIFF
--- a/components/SoftwareExperience/SoftwareExperience.module.css
+++ b/components/SoftwareExperience/SoftwareExperience.module.css
@@ -45,10 +45,11 @@
 
 .headingSecondary {
   font-family: "Bebas Neue", "Oswald", sans-serif;
-  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  font-size: clamp(1.3rem, 4vw, 2.2rem);
   color: var(--text-color);
   margin-top: 2rem;
   margin-bottom: 0.75rem;
+  hyphens: auto;
 }
 
 /* List styling */

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -96,7 +96,7 @@
   },
   "software": {
     "heading": "Software Experience & Certifications",
-    "certHeading": "Certifications",
+    "certHeading": "Certifi­cations",
     "skillsHeading": "Software & Programming Skills",
     "cert1": "SolidWorks Mechanical Design Associate – Issued: May 2019 – No expiration. Credential ID: C-5SUCTJW3L4. Validated proficiency in 3D CAD modeling, assembly creation and drawings using SolidWorks.",
     "cert2": "Basisveiligheid VCA – Issued: March 2018 – Expires: March 2028. Credential ID: 541448.05174689. Certified in occupational health & safety for high‑risk environments (Dutch/Belgian VCA standards).",


### PR DESCRIPTION
## Summary
- shrink heading size for small screens and enable word breaking
- add soft hyphen to certifications translation so the word can wrap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683d411175208326a84ba05e10c653c1