### PR TITLE
Fix intro center alignment on mobile

### DIFF
--- a/components/Introduction/Introduction.module.css
+++ b/components/Introduction/Introduction.module.css
@@ -143,6 +143,12 @@
     text-align: center;
     align-items: center;
   }
+  .title,
+  .subtitle,
+  .buttons,
+  .socials {
+    padding-left: 0;
+  }
   .buttons {
     justify-content: center;
   }


### PR DESCRIPTION
## Summary
- ensure intro section text has no left padding on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683d410712fc83268cbf72ebd3acacc3