### PR TITLE
Enhance skill cards and maintain theme integration

### DIFF
--- a/components/Skills/Skills.module.css
+++ b/components/Skills/Skills.module.css
@@ -1,69 +1,72 @@
 .wrapper {
-    position: relative;
-    padding: clamp(4rem, 7vw, 6rem) 1rem;
-    display: flex;
-    background: transparent;
-    justify-content: center;
-    color: var(--light-text);
+  position: relative;
+  padding: clamp(4rem, 7vw, 6rem) 1rem;
+  display: flex;
+  background: transparent;
+  justify-content: center;
+  color: var(--light-text);
+}
 
-  }
-  
-  .inner {
-    position: relative;
-    z-index: 1;
-    max-width: 1080px;
-    width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 1.25rem;
-  }
-  
+.inner {
+  position: relative;
+  z-index: 1;
+  max-width: 1200px;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
 .skillCard {
-    box-sizing: border-box;
-    background: var(--card-bg);
-    border-radius: var(--card-radius);
-    padding: 1.25rem 1.5rem;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.6rem;
-    box-shadow: 0 8px 28px rgb(0 0 0 / 0.35);
-    backdrop-filter: blur(6px);
-    transition: transform 0.25s ease;
+  position: relative;
+  box-sizing: border-box;
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 1.75rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.8rem;
+  box-shadow: 0 10px 32px rgb(0 0 0 / 0.35);
+  backdrop-filter: blur(6px);
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.skillCard:hover {
+  transform: translateY(-4px) scale(1.02);
+  border-color: var(--accent);
+}
+
+.skillTitle {
+  font-family: "Bebas Neue", "Oswald", sans-serif;
+  font-size: clamp(1.7rem, 3vw, 2.2rem);
+  letter-spacing: 0.03em;
+  margin: 0;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.tagGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  line-height: 1.1;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  word-break: break-word;
+}
+
+@media (max-width: 576px) {
+  .inner {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
-  
-  .skillCard:hover {
-    transform: translateY(-6px) scale(1.02);
-  }
-  
-  .skillTitle {
-    font-family: "Bebas Neue", "Oswald", sans-serif;
-    font-size: clamp(1.4rem, 2.4vw, 1.8rem);
-    letter-spacing: 0.02em;
-    margin: 0;
-    color: var(--accent);
-    text-transform: uppercase;
-  }
-  
-  .tagGrid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.4rem;
-  }
-  
-  .tag {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 9999px;
-    padding: 0.25rem 0.65rem;
-    font-size: 0.75rem;
-    line-height: 1.1;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-  }
-  
-  @media (max-width: 576px) {
-    .inner {
-      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    }
-  }
+}

--- a/components/Skills/Skills.tsx
+++ b/components/Skills/Skills.tsx
@@ -42,7 +42,11 @@ export default function Skills() {
     <section id="skills" className={classes.wrapper}>
       <div className={classes.inner}>
         {skills.map((skill) => (
-          <article key={skill.category} className={classes.skillCard}>
+          <article
+            key={skill.category}
+            className={classes.skillCard}
+            style={{ minWidth: "250px" }}
+          >
             <h3 className={classes.skillTitle}>{t(skill.category)}</h3>
             <div className={classes.tagGrid}>
               {skill.tools.map((tool) => (


### PR DESCRIPTION
## Summary
- widen skills grid and increase padding
- restore card background to var-based color
- enlarge fonts and tags for readability
- adjust skill card min width in JSX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d40fe86d88326a445bf5d80d8dc7f